### PR TITLE
added asset for non-resource

### DIFF
--- a/core/jazz_assets/config/global-config.json
+++ b/core/jazz_assets/config/global-config.json
@@ -45,7 +45,12 @@
     "service_bus",
     "functionapp",
     "storage_container",
-    "cosmosdb"
+    "cosmosdb_account",
+    "cosmosdb_database",
+    "cosmosdb_collection",
+    "storage_blob_container",
+    "servicebus_queue",
+    "eventhubs_eventhub"
 	],
 	"ASSET_STATUS": [
 		"active",


### PR DESCRIPTION

### Description of the Change

Add all the assets to asset table including azure resource with id or azure components without id.
This is to help users to use the info to create client to invoke the function.  
