### PR TITLE
Removed service_creation_data.events.length == 0 since this is incorrect for cron

### DIFF
--- a/core/jazz_create-serverless-service/index.js
+++ b/core/jazz_create-serverless-service/index.js
@@ -60,9 +60,6 @@ var handler = (event, context, cb) => {
             return cb(JSON.stringify(errorHandler.throwInputValidationError("'Service Name' can have up to 20 characters")));
         } else if (service_creation_data.domain && service_creation_data.domain.length > 20) {
             return cb(JSON.stringify(errorHandler.throwInputValidationError("'Namespace' can have up to 20 characters")));
-        }else if (service_creation_data.service_type === "function" && service_creation_data.platform === "azure" && service_creation_data.events.length == 0)
-        {
-          return cb(JSON.stringify(errorHandler.throwInputValidationError("'EventSource' is required")));
         }
 
         // validate service types


### PR DESCRIPTION

### Description of the Change

Removed server side validation since it broke when creating cron trigger function.  No event source length.
